### PR TITLE
Updated the build() function to correctly identify xdelta

### DIFF
--- a/Installer Package Files/20XX-5.0-convert.sh
+++ b/Installer Package Files/20XX-5.0-convert.sh
@@ -32,8 +32,8 @@ checkhash () {
 
 build () {
 	# Confirm that xdelta is installed
-	if type xdelta >/dev/null 2>&1; then
-		echo >&2 "xdelta does not appear to be installed. Exiting script.\n"
+	if [ ! -n "`command -v $xdelta 2>/dev/null`" ] ; then
+		echo >&2 "xdelta does not appear to be installed. Exiting script."
 		exit 1
 	fi
 


### PR DESCRIPTION
Changed the if statement to include a test, as it was always resulting in true and not allowing the script to run. Exchanged `type` for `command -v` which allows use `test -n`, to see if the string is empty or not.