### PR TITLE
Added check for common package managers instead of assuming apt-get

### DIFF
--- a/Installer Package Files/ReadMe and MD5s.txt
+++ b/Installer Package Files/ReadMe and MD5s.txt
@@ -105,5 +105,5 @@ https://github.com/DRGN-DRC/20XX-HACK-PACK
 :: 20XXHP updates to v5.0 and up by DRGN
 :: xdelta program created by Josh Macdonald
 :: Batch build script and xdelta files created by DRGN.
-:: Linux build script created by shuall, phonos, DRGN, and Mage
+:: Linux build script created by shuall, phonos, DRGN, Mage and Nosen92
 


### PR DESCRIPTION
The linux install script assumed that the package manager always was apt-get. Instead of hardcoding for apt-get, the script now checks for common package managers and uses the one it can find.

The compatible package managers are:

- apt-get
- dnf
- pacman

which should cover almost all linux machines. More can easily be added in the future.

Minor tweak: Changed (y/n) to (y/N) to highlight default.